### PR TITLE
Restore listings hidden by the price comparison window

### DIFF
--- a/UniversalisCommon/Definitions.cs
+++ b/UniversalisCommon/Definitions.cs
@@ -8,6 +8,8 @@ namespace UniversalisCommon
     {
         public short PlayerSpawn { get; set; }
         public short PlayerSetup { get; set; }
+        public short RetainerState { get; set; }
+        public short RetainerSummary { get; set; }
         public short MarketBoardItemRequestStart { get; set; }
         public short MarketBoardOfferings { get; set; }
         public short MarketBoardHistory { get; set; }

--- a/UniversalisCommon/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/UniversalisCommon/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -173,9 +173,12 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders
                 return;
             }
 
+            // Add rejects a listing the snapshot already carries, and a second copy of one
+            // the API returned twice - which it does, so filtering against the snapshot
+            // alone would upload the same listing more than once.
             var present = new HashSet<ulong>(uploadRequest.Listings.Select(l => l.ListingId));
             var hidden = listings.ToObject<List<UniversalisItemListingsEntry>>(ListingSerializer)
-                .Where(l => l.RetainerId == retainerId && !present.Contains(l.ListingId))
+                .Where(l => l.RetainerId == retainerId && present.Add(l.ListingId))
                 .ToList();
             if (hidden.Count == 0)
             {

--- a/UniversalisCommon/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
+++ b/UniversalisCommon/MarketBoardUploaders/Universalis/UniversalisMarketBoardUploader.cs
@@ -1,7 +1,9 @@
 using System;
 using System.Collections.Generic;
 using System.Diagnostics;
+using System.Linq;
 using System.Net;
+using System.Text;
 using Dalamud.Game.Network.MarketBoardUploaders;
 using Dalamud.Game.Network.MarketBoardUploaders.Universalis;
 using Newtonsoft.Json;
@@ -14,6 +16,12 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders
     internal class UniversalisMarketBoardUploader : IMarketBoardUploader
     {
         private const string ApiBase = "https://universalis.app";
+        private const string UserAgent = "universalis_uploader";
+        private const int ReadTimeoutMs = 20000;
+
+        // sellerID and creatorID arrive null and will not convert to ulong.
+        private static readonly JsonSerializer ListingSerializer = JsonSerializer.Create(
+            new JsonSerializerSettings { NullValueHandling = NullValueHandling.Ignore });
 
         private readonly PacketProcessor _packetProcessor;
         private readonly string _apiKey;
@@ -80,6 +88,11 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders
                     Timestamp = ((DateTimeOffset)marketBoardHistoryListing.PurchaseTime).ToUnixTimeSeconds(),
                 });
 
+            if (_packetProcessor.CurrentRetainerId is ulong retainerId)
+            {
+                RestoreHiddenListings(uploadRequest, retainerId);
+            }
+
             client.Headers.Add(HttpRequestHeader.ContentType, "application/json");
             SubmitData(client, uploadRequest);
 
@@ -124,6 +137,71 @@ namespace Dalamud.Game.Network.Universalis.MarketBoardUploaders
             var requestStr = JsonConvert.SerializeObject(data);
             Trace.WriteLine(requestStr);
             client.UploadString(ApiBase + $"/upload/{_apiKey}", "POST", requestStr);
+        }
+
+        /// <summary>
+        /// A summoned retainer's listings are withheld from the price comparison window,
+        /// so a snapshot taken there reads as a removal for listings that are still live.
+        /// Restores them from Universalis' own rows: the game never tells a client what
+        /// listing IDs its listings were assigned, and a reconstructed ID would post as
+        /// an add and a remove rather than as a no-op.
+        /// </summary>
+        private void RestoreHiddenListings(UniversalisMarketBoardUploadRequest uploadRequest, ulong retainerId)
+        {
+            JToken listings;
+            try
+            {
+                // DownloadString otherwise decodes as ANSI and mangles retainer names.
+                using var client = new TimedWebClient { Encoding = Encoding.UTF8 };
+                client.Headers.Add(HttpRequestHeader.UserAgent, UserAgent);
+                var json = client.DownloadString(
+                    $"{ApiBase}/api/v2/{uploadRequest.WorldId}/{uploadRequest.ItemId}" +
+                    "?entries=0&statsWithin=0&fields=listings");
+                listings = JObject.Parse(json)["listings"];
+            }
+            catch (Exception ex)
+            {
+                _packetProcessor.Log?.Invoke(this,
+                    $"[WARN] Could not fetch listings for item#{uploadRequest.ItemId}; uploading unmodified:\n{ex.Message}");
+                return;
+            }
+
+            if (listings == null)
+            {
+                _packetProcessor.Log?.Invoke(this,
+                    $"[WARN] Listings response for item#{uploadRequest.ItemId} had no listings key; uploading unmodified.");
+                return;
+            }
+
+            var present = new HashSet<ulong>(uploadRequest.Listings.Select(l => l.ListingId));
+            var hidden = listings.ToObject<List<UniversalisItemListingsEntry>>(ListingSerializer)
+                .Where(l => l.RetainerId == retainerId && !present.Contains(l.ListingId))
+                .ToList();
+            if (hidden.Count == 0)
+            {
+                return;
+            }
+
+            uploadRequest.Listings.AddRange(hidden);
+            _packetProcessor.Log?.Invoke(this,
+                $"Restored {hidden.Count} hidden listing(s) for retainer#{retainerId} on item#{uploadRequest.ItemId}.");
+        }
+
+        /// <summary>
+        /// WebClient has no timeout property and defaults to 100 seconds.
+        /// </summary>
+        private class TimedWebClient : WebClient
+        {
+            protected override WebRequest GetWebRequest(Uri address)
+            {
+                var request = base.GetWebRequest(address);
+                if (request != null)
+                {
+                    request.Timeout = ReadTimeoutMs;
+                }
+
+                return request;
+            }
         }
     }
 }

--- a/UniversalisCommon/PacketProcessor.cs
+++ b/UniversalisCommon/PacketProcessor.cs
@@ -26,6 +26,7 @@ namespace UniversalisCommon
 
         public uint CurrentWorldId { get; set; }
         public string UploaderId { get; }
+        public ulong? CurrentRetainerId { get; private set; }
 
         public EventHandler<string> Log;
 
@@ -52,15 +53,31 @@ namespace UniversalisCommon
                 .ExecuteAsync(() => Task.Run(() =>
                 {
                     var definitions = Definitions.Get();
-                    _packetHandlers = new Dictionary<short, Func<byte[], bool>>
+                    var handlers = new (string Name, short Opcode, Func<byte[], bool> Handler)[]
                     {
-                        { definitions.PlayerSpawn, ProcessPlayerSpawn },
-                        { definitions.MarketBoardItemRequestStart, ProcessMarketBoardItemRequestStart },
-                        { definitions.MarketBoardOfferings, ProcessMarketBoardOfferings },
-                        { definitions.MarketBoardHistory, ProcessMarketBoardHistory },
-                        { definitions.MarketTaxRates, ProcessMarketTaxRates },
-                        { definitions.ContentIdNameMapResp, ProcessContentIdNameMapResp },
+                        (nameof(definitions.PlayerSpawn), definitions.PlayerSpawn, ProcessPlayerSpawn),
+                        (nameof(definitions.PlayerSetup), definitions.PlayerSetup, ClearRetainerContext),
+                        (nameof(definitions.RetainerState), definitions.RetainerState, ProcessRetainerState),
+                        (nameof(definitions.RetainerSummary), definitions.RetainerSummary, ClearRetainerContext),
+                        (nameof(definitions.MarketBoardItemRequestStart), definitions.MarketBoardItemRequestStart, ProcessMarketBoardItemRequestStart),
+                        (nameof(definitions.MarketBoardOfferings), definitions.MarketBoardOfferings, ProcessMarketBoardOfferings),
+                        (nameof(definitions.MarketBoardHistory), definitions.MarketBoardHistory, ProcessMarketBoardHistory),
+                        (nameof(definitions.MarketTaxRates), definitions.MarketTaxRates, ProcessMarketTaxRates),
+                        (nameof(definitions.ContentIdNameMapResp), definitions.ContentIdNameMapResp, ProcessContentIdNameMapResp),
                     };
+
+                    // An opcode the definitions file omits deserializes to 0, and two of
+                    // those collide, leaving the client with no handlers at all.
+                    var missing = handlers.Where(h => h.Opcode <= 0).Select(h => h.Name).ToList();
+                    if (missing.Count > 0)
+                    {
+                        Log?.Invoke(this,
+                            $"[WARN] Opcode definitions carry no {string.Join(", ", missing)}; those packets are ignored.");
+                    }
+
+                    _packetHandlers = handlers
+                        .Where(h => h.Opcode > 0)
+                        .ToDictionary(h => h.Opcode, h => h.Handler);
                 }))
                 .SafeFireAndForget(
                     continueOnCapturedContext: true,
@@ -282,6 +299,31 @@ namespace UniversalisCommon
             });
 
             Log?.Invoke(this, $"NEW MB REQUEST START: Expecting {amount} listings");
+            return false;
+        }
+
+        private bool ProcessRetainerState(byte[] message)
+        {
+            var retainerId = BitConverter.ToUInt64(message, 0x20);
+            if (retainerId != CurrentRetainerId)
+            {
+                CurrentRetainerId = retainerId;
+                Log?.Invoke(this, $"Retainer summoned: #{retainerId}");
+            }
+
+            return false;
+        }
+
+        private bool ClearRetainerContext(byte[] message)
+        {
+            if (CurrentRetainerId == null)
+            {
+                return false;
+            }
+
+            CurrentRetainerId = null;
+            Log?.Invoke(this, "No retainer summoned.");
+
             return false;
         }
 

--- a/definitions.json
+++ b/definitions.json
@@ -1,1 +1,1 @@
-{"ClientTrigger":-1,"PlayerSpawn":113,"PlayerSetup":935,"ItemMarketBoardInfo":969,"MarketBoardItemRequestStart":230,"MarketBoardOfferings":348,"MarketBoardHistory":319,"MarketTaxRates":847,"ContentIdNameMapResp":-1}
+{"ClientTrigger":-1,"PlayerSpawn":113,"PlayerSetup":935,"RetainerState":606,"RetainerSummary":655,"ItemMarketBoardInfo":969,"MarketBoardItemRequestStart":230,"MarketBoardOfferings":348,"MarketBoardHistory":319,"MarketTaxRates":847,"ContentIdNameMapResp":-1}

--- a/update_definitions.mjs
+++ b/update_definitions.mjs
@@ -14,6 +14,8 @@ fetch(opcodesUrl)
         ClientTrigger: -1,
         PlayerSpawn: getOpcode(lists.ServerZoneIpcType, 'PlayerSpawn'),
         PlayerSetup: getOpcode(lists.ServerZoneIpcType, 'PlayerSetup'),
+        RetainerState: getOpcode(lists.ServerZoneIpcType, 'RetainerState'),
+        RetainerSummary: getOpcode(lists.ServerZoneIpcType, 'RetainerSummary'),
         ItemMarketBoardInfo: getOpcode(lists.ServerZoneIpcType, 'ItemMarketBoardInfo'),
         MarketBoardItemRequestStart: getOpcode(lists.ServerZoneIpcType, 'MarketBoardItemListingCount'),
         MarketBoardOfferings: getOpcode(lists.ServerZoneIpcType, 'MarketBoardItemListing'),


### PR DESCRIPTION
A summoned retainer's listings are withheld from the price comparison window. A snapshot taken there is missing them, so they are diffed against stored state and published as listings/remove for listings that are still live. On rarely-uploaded items nothing contradicts that and the removal sticks. Measured at 1.40% of 4,631 remove probes against 0.04% of 2,501 add probes across 6 worlds. 
A player adjusting the price on their listings leaves a trail of removes on their retainer's listings, identifying them as an uploader and breaking the promise of anonymity. This fix re-inserts the retainer's listings if they were present in Universalis' database, resulting in a no-op on those listings. While the re-inserted listings remain stale if the player adjusted the price or removed the listing, their uploads no longer link back to them.

The summoned retainer is tracked from three received packets:

  RetainerState   (606) sets it - carries the retainer's content id at
                        payload +0 as a u64
  RetainerSummary (655) clears it - the retainer overview is only
                        reachable by dismissing whatever was summoned
  PlayerSetup     (935) clears it - login only, so it covers a crash,
                        the one exit that skips the overview

When an upload is built while a retainer is summoned, that item's current listings are fetched from the v2 REST API for the current world, and any belonging to that retainer which the snapshot does not already carry are added back. The fetch is necessary since the game server does not report listing IDs for a listing shown in the retainer menu. The insert is keyed on listing ID, so it does nothing when nothing was hidden. A failed or unusable fetch logs a warning and uploads unmodified.

Both opcodes are already in FFXIVOpcodes' ServerZoneIpcType, so update_definitions.mjs needs only the two lines - but act.universalis.app has to serve a regenerated definitions.json before any of this takes effect. Until it does, the new fields deserialize to 0. Two zero keys collide in the handler dictionary, which throws inside SafeFireAndForget and leaves _packetHandlers null, so the client silently stops uploading anything at all. The table now skips non-positive opcodes and names them in a warning instead.

Code written by Claude, hand-checked and tested in-game on 7.55 against a live comparison-window snapshot using the standalone uploader.

Some notes:
- The WebClient timeout is set to 20 seconds, which covers even the slowest responses by the REST API I've seen so far. However, this means packet handling can still be blocked for up to 20 seconds. A better approach would be to handle uploads asynchronously, but that is a change way outside the scope of this fix.
- Using packet data, a removal or price adjustment could be inserted into the re-inserted listings. However, this would once again leave a trail that identifies the uploader.